### PR TITLE
New Rails version, allow higher multi_json version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,27 +2,27 @@ PATH
   remote: .
   specs:
     ops (2.0.0)
-      activesupport (~> 3.2.0)
+      activesupport (~> 3.2.0, >= 3.2.13)
       httpclient (~> 2.2.5)
-      multi_json (~> 1.3.6)
+      multi_json (~> 1.3, >= 1.3.6)
       nokogiri (~> 1.5.5)
       oj (~> 1.3.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.12)
-      i18n (~> 0.6)
+    activesupport (3.2.13)
+      i18n (= 0.6.1)
       multi_json (~> 1.0)
-    addressable (2.3.2)
+    addressable (2.3.4)
     awesome_print (1.1.0)
     crack (0.3.2)
     diff-lcs (1.1.3)
     flexmock (1.0.4)
     httpclient (2.2.7)
     i18n (0.6.1)
-    multi_json (1.3.7)
-    nokogiri (1.5.6)
+    multi_json (1.7.2)
+    nokogiri (1.5.9)
     oj (1.3.7)
     rake (0.9.2.2)
     rspec (2.11.0)

--- a/ops.gemspec
+++ b/ops.gemspec
@@ -46,10 +46,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = %w(lib)
 
-  s.add_runtime_dependency "activesupport", "~> 3.2.0"
+  s.add_runtime_dependency "activesupport", "~> 3.2.0", ">= 3.2.13"
   s.add_runtime_dependency "nokogiri", "~> 1.5.5"
   s.add_runtime_dependency "httpclient", "~> 2.2.5"
-  s.add_runtime_dependency "multi_json", "~> 1.3.6"
+  s.add_runtime_dependency "multi_json", "~> 1.3", ">= 1.3.6"
   s.add_runtime_dependency "oj", "~> 1.3.0"
 
   s.add_development_dependency "rake", "~> 0.9.2.2"


### PR DESCRIPTION
- multi_json wants to be 1.7.x
- Rails 3.2.12 has a serious security vulnerability
