### PR TITLE
README + gemspec: Required ruby ~> 1.9.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,3 @@ DEPENDENCIES
   rspec (~> 2.14.1)
   vcr (~> 2.9.0)
   webmock (~> 1.17.4)
-
-BUNDLED WITH
-   1.10.6

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ About
 This gem has been developed as part of the exemplar tool ChemBioNavigator within Open PHACTS (http://www.openphacts.org/). It is distributed under the MIT license (see LICENSE for more details).
 
 
+Requirements
+------------
+
+* Ruby ~> 1.9.3
+
+
 Installation
 ------------
 

--- a/ops.gemspec
+++ b/ops.gemspec
@@ -46,6 +46,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = %w(lib)
 
+  s.required_ruby_version = '~> 1.9.3'
+
   s.add_runtime_dependency "activesupport", "~> 3.2.0"
   s.add_runtime_dependency "nokogiri", "~> 1.5.10"
   s.add_runtime_dependency "httpclient", "~> 2.6"


### PR DESCRIPTION
Doch noch mal als Pull-Request:

Habe das auch in ops.gemspec eingetragen (s.required_ruby_version = '~> 1.9.3'), allerdings taucht davon nichts in Gemfile.lock auf.  Ist das richtig?
